### PR TITLE
fix: change to respond the same object

### DIFF
--- a/src/frourio-express/api/controller.ts
+++ b/src/frourio-express/api/controller.ts
@@ -1,5 +1,5 @@
 import { defineController } from './$relay'
 
 export default defineController(() => ({
-  get: () => ({ status: 200, body: 'Hello world' })
+  get: () => ({ status: 200, body: { hello: "world" } })
 }))

--- a/src/frourio-express/api/index.ts
+++ b/src/frourio-express/api/index.ts
@@ -1,5 +1,7 @@
 export type Methods = {
   get: {
-    resBody: string
+    resBody: {
+      hello: string
+    }
   }
 }

--- a/src/frourio/api/controller.ts
+++ b/src/frourio/api/controller.ts
@@ -1,5 +1,5 @@
 import { defineController } from './$relay'
 
 export default defineController(() => ({
-  get: () => ({ status: 200, body: 'Hello world' })
+  get: () => ({ status: 200, body: { hello: "world" } })
 }))

--- a/src/frourio/api/index.ts
+++ b/src/frourio/api/index.ts
@@ -1,5 +1,7 @@
 export type Methods = {
   get: {
-    resBody: string
+    resBody: {
+      hello: string
+    }
   }
 }


### PR DESCRIPTION
Example of fastify: https://github.com/frouriojs/benchmarks/blob/6e9695d/benchmarks/fastify.js#L5-L22

Now: `"Hello world"`
Change to: `{ "hello": "world" }`
